### PR TITLE
Remove mapping of removed upstream service

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -140,8 +140,6 @@ func Provider() tfbridge.ProviderInfo {
 		DataSources: map[string]*tfbridge.DataSourceInfo{
 			"signalfx_dimension_values": {Tok: makeDataSource(mainMod, "getDimensionValues")},
 
-			"signalfx_gcp_services": {Tok: makeDataSource(gcpMod, "getServices")},
-
 			"signalfx_pagerduty_integration": {Tok: makeDataSource(pagerdutyMod, "getIntegration")},
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
@@ -157,7 +155,8 @@ func Provider() tfbridge.ProviderInfo {
 			i := &tfbridge.PythonInfo{
 				Requires: map[string]string{
 					"pulumi": ">=3.0.0,<4.0.0",
-				}}
+				},
+			}
 			i.PyProject.Enabled = true
 			return i
 		})(),


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-signalfx/issues/345

`signalfx_gcp_services` was removed in the upstream release `8.0.0`. https://github.com/splunk-terraform/terraform-provider-signalfx/blob/dd30239bcf39e43b89ecc49734cdbf0385714577/CHANGELOG.md?plain=1#L18. 

It is last available in 7.0.0: https://registry.terraform.io/providers/splunk-terraform/signalfx/7.0.0/docs/data-sources/gcp_services

I wonder why it errors only now? 

